### PR TITLE
Ignore transitions that haven't been declared in the plugin params

### DIFF
--- a/agent/src/com/amirov/jirareporter/Reporter.java
+++ b/agent/src/com/amirov/jirareporter/Reporter.java
@@ -31,7 +31,10 @@ public class Reporter {
         NullProgressMonitor pm = new NullProgressMonitor();
         if(RunnerParamsProvider.progressIssueIsEnable() == null){}
         else if(RunnerParamsProvider.progressIssueIsEnable().equals("true")){
-            getRestClient().getIssueClient().transition(getIssue().getTransitionsUri(), getTransitionInput(JIRAConfig.prepareJiraWorkflow(parser.getStatusBuild()).get(getIssueStatus())), pm);
+            String transitionName = JIRAConfig.prepareJiraWorkflow(parser.getStatusBuild()).get(getIssueStatus());
+            if (transitionName != null) {
+                getRestClient().getIssueClient().transition(getIssue().getTransitionsUri(), getTransitionInput(transitionName), pm);
+            }
         }
     }
 


### PR DESCRIPTION
In certain scenarios one may not want an issue to make a status transition after a successful build. For example, in a feature branch spanning multiple commits where the corresponding case is "In Progress", I do want TeamCity to trigger a build on each commit (and notify JIRA of the results). However, I do not want it to transition the case to "Resolved" until/unless I declare that I am done working on the issue (for example, by using a JIRA smart commit).

This patch changes the reporter behavior to attempt a status transition only if one has been declared in the plugin parameters. For example, given the following workflow configuration:

```
SUCCESS:Building-Build Passed;
FAILURE:Building-Build Failed;
```

The reporter will then only attempt to transition an issue if it has "Building" as its current status. If the issue has any other status, no transition will be attempted.
